### PR TITLE
Replace log with logrus

### DIFF
--- a/fws/creds.go
+++ b/fws/creds.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"os/user"
 	"path/filepath"

--- a/fws/resource_fws_database.go
+++ b/fws/resource_fws_database.go
@@ -2,7 +2,7 @@ package fws
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-fakewebservices/client"

--- a/fws/resource_fws_load_balancer.go
+++ b/fws/resource_fws_load_balancer.go
@@ -2,7 +2,7 @@ package fws
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-fakewebservices/client"

--- a/fws/resource_fws_server.go
+++ b/fws/resource_fws_server.go
@@ -2,7 +2,7 @@ package fws
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-fakewebservices/client"

--- a/fws/resource_fws_vpc.go
+++ b/fws/resource_fws_vpc.go
@@ -2,7 +2,7 @@ package fws
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-fakewebservices/client"

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"flag"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 	"github.com/hashicorp/terraform-provider-fakewebservices/fws"


### PR DESCRIPTION
stdout: Namespace(repository='github.com/sourcegraph-ce/terraform-provider-fakewebservices', batch_change_name='log-provider-go-with-python-script-2', description='This batch change opens a PR for each .go file in a terraform provider repository, and replaces the standard library "log" import statement with the "logrus" library.  This batch change for each repository where the import "log" statement is replaced with "logrus".\n', secret='supersecret', reopen=False)
templates
.release
scripts
.github
docs
tools
.git
fws
client
workflows
resources
objects
info
branches
logs
refs
hooks
94
9f
49
12
47
81
8e
3f
4a
0e
69
a9
6c
ff
43
3e
b8
c1
pack
ef
e8
da
e0
info
3c
c6
d4
27
3b
0c
af
a8
5e
35
16
6b
23
8f
04
7b
6a
cc
45
a1
62
df
4d
refs
heads
tags
heads

[_Created by Sourcegraph batch change `admin/log-provider-go-with-python-script-2`._](https://gcp.s0urcegraph.com/users/admin/batch-changes/log-provider-go-with-python-script-2)